### PR TITLE
Fixed track event utme issue where utme was prefixed by "null" causing events not to track correctly

### DIFF
--- a/src/googleAnalytics/Internals/Request/EventRequest.hx
+++ b/src/googleAnalytics/Internals/Request/EventRequest.hx
@@ -81,7 +81,8 @@ class EventRequest extends Request {
 		var eventFragment:String = x10.renderUrlString();
 		// Append only if not null to avoid "null" in event fragments
 		if (eventFragment != null) {
-			p.utme = eventFragment;
+			if(p.utme == null) p.utme = eventFragment;
+			else p.utme += eventFragment;
 		}
 		
 		if(this.event.getNoninteraction()) {

--- a/src/googleAnalytics/Internals/Request/PageviewRequest.hx
+++ b/src/googleAnalytics/Internals/Request/PageviewRequest.hx
@@ -56,7 +56,8 @@ class PageviewRequest extends Request {
 		if(this.page.getLoadTime()!=0) {
 			// Sample sitespeed measurements
 			if(p.utmn % 100 < this.config.getSitespeedSampleRate()) {
-				p.utme += 0;
+				if(p.utme == null) p.utme = "" + 0;
+				else p.utme += 0;
 			}
 		}
 		

--- a/src/googleAnalytics/Internals/Request/Request.hx
+++ b/src/googleAnalytics/Internals/Request/Request.hx
@@ -259,7 +259,8 @@ class Request {
 		var eventFragment:String = x10.renderUrlString();
 		// Append only if not null to avoid "null" in event fragments
 		if (eventFragment != null) {
-			p.utme += eventFragment;
+			if(p.utme == null) p.utme = eventFragment;
+			else p.utme += eventFragment;
 		}
 		return p;
 	}


### PR DESCRIPTION
Fixed tracking issue (on haxe 2.1 at least) where the utme was incorrectly built. The utme was built with null + event details. This prevented me from correctly updating sending analytics events event the correct event details were being included.

When/if this fix is merge could you please update the haxelib (2.1) so that the rest of the developers can get this fix. Thanks, Phil.
