### PR TITLE
Enhance error handling

### DIFF
--- a/src/googleAnalytics/internals/request/Request.hx
+++ b/src/googleAnalytics/internals/request/Request.hx
@@ -113,7 +113,9 @@ class Request {
 	}
 
 	public function onError (e:String) {
+		#if !silentRequest
 		trace('ERROR: '+e);
+		#end
 	}
 
 	private function increaseTrackCount() {
@@ -159,6 +161,10 @@ class Request {
 			var l : flash.display.Loader = new flash.display.Loader();
 			var urlRequest : flash.net.URLRequest=new flash.net.URLRequest();
 			urlRequest.url=url;
+			
+			//flash have unspoken error that can happen nonetheless due to denied DNS resolution...
+			l.contentLoaderInfo.addEventListener( flash.events.IOErrorEvent.IO_ERROR, function(e:flash.events.IOErrorEvent) onError(e.text) );
+			
 			try{ l.load(urlRequest); }catch(e:Dynamic){}
 		#else
 			var request : Http = new Http(url);


### PR DESCRIPTION
We stumbled on DNS denial dued to adblockers, here is the fix for the lib to stay consistent. I you could do a haxelib release it would be super awesome.

We also added a flag to silence the lib on purpose (you can refuse this one but it is practical.

Thanks you for your awesome work.
