### PR TITLE
Added support for different url schemes

### DIFF
--- a/src/googleAnalytics/Config.hx
+++ b/src/googleAnalytics/Config.hx
@@ -92,6 +92,11 @@ class Config {
 	// FIXME: Add SSL support, https://ssl.google-analytics.com
 	
 	/**
+	 * Setting this to 'https' allows analytics to be sent over SSL.
+	 */
+	private var urlScheme : String = 'http';
+	
+	/**
 	 * Google Analytics tracking request endpoint host. Can be set to null to
 	 * silently simulate (and log) requests without actually sending them.
 	 * @see internals.request.HttpRequest::send()
@@ -113,7 +118,8 @@ class Config {
 	 */
 	private var sitespeedSampleRate : Int = 1;
 		
-	public function new() {
+	public function new(useSSL:Bool = false) {
+		setUrlScheme('http' + (useSSL ? 's' : ''));
 		/*for(property => value in properties) {
 			// PHP doesn't care about case in method names
 			setterMethod = 'set' + property;
@@ -170,6 +176,14 @@ class Config {
 	
 	public function setRequestTimeout(requestTimeout:Float) {
 		this.requestTimeout = requestTimeout;
+	}
+	
+	public function getUrlScheme() : String {
+		return this.urlScheme;
+	}
+	
+	public function setUrlScheme(urlScheme:String) : String {
+		return this.urlScheme = urlScheme;
 	}
 	
 	public function getEndPointHost() : String {

--- a/src/googleAnalytics/internals/request/Request.hx
+++ b/src/googleAnalytics/internals/request/Request.hx
@@ -144,7 +144,7 @@ class Request {
 			parameters.utmvid = visitor.getUniqueId();
 		}
 		var queryString : String = Util.convertToUriComponentEncoding(parameters.toQueryString());
-		var url : String = 'http://' + config.getEndPointHost() + config.getEndPointPath() + '?' + queryString;
+		var url : String = config.getUrlScheme() + '://' + config.getEndPointHost() + config.getEndPointPath() + '?' + queryString;
 		increaseTrackCount();
 		#if js
 			// well, in javascript ocurrs the same thing with CORS, so no request, just load an image.
@@ -164,8 +164,8 @@ class Request {
 			if(userAgent!=null && userAgent!='') {
 				request.setHeader('User-Agent', userAgent);
 			}
-			request.setHeader('Host', 'http://'+config.getEndPointHost());
-			request.setHeader('Connection', 'close');		
+			request.setHeader('Host', config.getUrlScheme() + config.getEndPointHost());
+			request.setHeader('Connection', 'close');
 			#if (neko||php||cpp||cs||java)
 				request.cnxTimeout=config.getRequestTimeout();
 			#end

--- a/src/haxelib.json
+++ b/src/haxelib.json
@@ -5,6 +5,6 @@
 	"contributors":["fbricker"],
 	"tags": ["cross","api","google","analytics"],
 	"description": "Generic Google Analytics client that implements nearly every parameter and tracking feature of the original GA Javascript client.",
-	"version": "0.4.12",
-	"releasenote": "Fix flash target: DNS Resolution exception issue fixed."
+	"version": "0.4.13",
+	"releasenote": "Added support for tracking events over SSL"
 }


### PR DESCRIPTION
I'm told by coworkers that simply specifying "https" rather than "http" as the google analytics tracking url will work - We need this to avoid issues when running our website in HTTPS and, currently, haxe-ga is hard coded to use HTTP links == bad times.
