### PR TITLE
openfl 3 compilation fix (for native targets)

### DIFF
--- a/src/googleAnalytics/Stats.hx
+++ b/src/googleAnalytics/Stats.hx
@@ -112,9 +112,10 @@ class Stats {
 			}
 		}
 		#end
-		#if (openfl && !flash && !html5)
-		version+="/" + Lib.packageName + "." + Lib.version;
-		#end
+		// There is no packageName info in OpenFL 3 at the moment
+		// #if (openfl && !flash && !html5)
+		// version+="/" + Lib.packageName + "." + Lib.version;
+		// #end
 
 		#if ios
 		visitor.setUserAgent('iOS'+version);


### PR DESCRIPTION
there is no support for these info in openfl 3 anymore, actually we can discuss and check major version of openfl and make more tricky checks for preprocessor... 
*Or the simplest solution is just drop that functionality from haxe-ga, and provide some customPackage setter outside of main module.*

https://github.com/fbricker/haxe-ga/issues/13