### PR TITLE
Fixing a bug around event value logic

### DIFF
--- a/src/googleAnalytics/internals/request/EventRequest.hx
+++ b/src/googleAnalytics/internals/request/EventRequest.hx
@@ -74,7 +74,7 @@ class EventRequest extends Request {
 			x10.setKey(/*self.*/X10_EVENT_PROJECT_ID, X10.LABEL_KEY_NUM, this.event.getLabel());
 		}
 		
-		if(this.event.getValue() != 0) {
+		if(this.event.getValue() >= 0) {
 			x10.setValue(/*self.*/X10_EVENT_PROJECT_ID, X10.VALUE_VALUE_NUM, this.event.getValue());
 		}
 		


### PR DESCRIPTION
According to this: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue

Events can have *non-negative* values, meaning that 0 and higher are acceptable. The original logic was a bit off since it disallowed 0, and allowed negatives.